### PR TITLE
Force is_secure=True on video tag

### DIFF
--- a/wagtail_embed_videos/templates/wagtail_embed_videos/chooser/results.html
+++ b/wagtail_embed_videos/templates/wagtail_embed_videos/chooser/results.html
@@ -21,7 +21,7 @@
                         {% if embed_video.thumbnail %}
                             {% image embed_video.thumbnail max-165x165 class="show-transparency" %}
                         {% else %}
-                            {% video embed_video.url as my_video %}
+                            {% video embed_video.url is_secure=True as my_video %}
                                 <img src="{{ my_video.thumbnail }}" class="show-transparency" style="max-width: 165px; max-height: 165px;">
                             {% endvideo %}
                         {% endif %}

--- a/wagtail_embed_videos/templates/wagtail_embed_videos/embed_videos/edit.html
+++ b/wagtail_embed_videos/templates/wagtail_embed_videos/embed_videos/edit.html
@@ -47,7 +47,7 @@
             </form>
         </div>
         <div class="col6 divider-before">
-            {% video embed_video.url as my_video %}
+            {% video embed_video.url is_secure=True as my_video %}
                 {% video my_video "small" %}
                 <br />
                 <strong>Backend</strong>: {{ my_video.backend }}

--- a/wagtail_embed_videos/templates/wagtail_embed_videos/widgets/embed_video_chooser.html
+++ b/wagtail_embed_videos/templates/wagtail_embed_videos/widgets/embed_video_chooser.html
@@ -9,7 +9,7 @@
             {% if embed_video.thumbnail %}
                 {% image embed_video.thumbnail max-130x130%}
             {% else %}
-                {% video embed_video.url as my_video %}
+                {% video embed_video.url is_secure=True as my_video %}
                     <img src="{{ my_video.thumbnail }}" style="max-width: 130px; max-height: 130px;">
                 {% endvideo %}
             {% endif %}


### PR DESCRIPTION
Without `is_secure=True`, fails to display video on https, when reverse proxied.