### PR TITLE
Allow wagtail video embed to function with custom image models

### DIFF
--- a/wagtail_embed_videos/migrations/0003_custom_image_model.py
+++ b/wagtail_embed_videos/migrations/0003_custom_image_model.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AlterField(
-            model_name='wagtail_embed_videos.embedvideo',
+            model_name='embedvideo',
             name='thumbnail',
             field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=get_image_model_string(), verbose_name='Thumbnail'),
         ),

--- a/wagtail_embed_videos/migrations/0003_custom_image_model.py
+++ b/wagtail_embed_videos/migrations/0003_custom_image_model.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from wagtail.images import get_image_model_string
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtail_embed_videos', '0002_auto_20180822_0945'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='wagtail_embed_videos.embedvideo',
+            name='thumbnail',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=get_image_model_string(), verbose_name='Thumbnail'),
+        ),
+    ]

--- a/wagtail_embed_videos/models.py
+++ b/wagtail_embed_videos/models.py
@@ -20,7 +20,10 @@ from django.urls import reverse
 from django.core.files import File
 from django.core.files.temp import NamedTemporaryFile
 
-from wagtail.admin.utils import get_object_usage
+try:
+    from wagtail.admin.models import get_object_usage
+except:
+    from wagtail.admin.utils import get_object_usage
 from wagtail.images.models import Image as WagtailImage
 from wagtail.images import get_image_model
 from wagtail.search import index

--- a/wagtail_embed_videos/models.py
+++ b/wagtail_embed_videos/models.py
@@ -15,7 +15,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
-from django.utils.encoding import python_2_unicode_compatible
 from django.urls import reverse
 from django.core.files import File
 from django.core.files.temp import NamedTemporaryFile
@@ -97,7 +96,6 @@ class EmbedVideoQuerySet(SearchableQuerySetMixin, models.QuerySet):
     pass
 
 
-@python_2_unicode_compatible
 class AbstractEmbedVideo(index.Indexed, models.Model):
     title = models.CharField(max_length=255, verbose_name=_('Title'))
     url = EmbedVideoField()

--- a/wagtail_embed_videos/views/chooser.py
+++ b/wagtail_embed_videos/views/chooser.py
@@ -4,7 +4,10 @@ from django.urls import reverse
 from embed_video.backends import detect_backend
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
-from wagtail.admin.utils import popular_tags_for_model
+try:
+    from wagtail.admin.models import popular_tags_for_model
+except:
+    from wagtail.admin.utils import popular_tags_for_model
 # from wagtail.utils.pagination import paginate
 
 from wagtail_embed_videos.models import get_embed_video_model

--- a/wagtail_embed_videos/views/embed_videos.py
+++ b/wagtail_embed_videos/views/embed_videos.py
@@ -11,7 +11,10 @@ from django.http import HttpResponse
 
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin import messages
-from wagtail.admin.utils import popular_tags_for_model
+try:
+    from wagtail.admin.models import popular_tags_for_model
+except:
+    from wagtail.admin.utils import popular_tags_for_model
 from wagtail.search.backends import get_search_backends
 
 from wagtail_embed_videos.models import get_embed_video_model


### PR DESCRIPTION
Currently this release functions with Wagtail 2.7 but uses migrations which do make use of the "get_image_model_string" function, meaning a custom image model will result in a foreign key error.

This can be resolved by adding a migration to alter the field thumbnail field.